### PR TITLE
Updated from Jessie to Stretch to update nginx.

### DIFF
--- a/lets-encrypt-reverse-proxy/Dockerfile
+++ b/lets-encrypt-reverse-proxy/Dockerfile
@@ -1,13 +1,12 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Louis Fradin <louis.fradin@gmail.com>
 
 # Update distrib
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
 RUN apt-get update
 
 # Install certbot and nginx
 RUN apt-get install -y nginx dnsmasq
-RUN apt-get install -y certbot -t jessie-backports
+RUN apt-get install -y certbot
 
 # Copy files
 COPY docker /docker


### PR DESCRIPTION
Changing to debian stretch allowed nginx to be updated to version 1.10.3.
I did not find anything broken in the container after the update.
This fixes #2 